### PR TITLE
fix: suppress job control notifications from spinner and claude processes

### DIFF
--- a/zsh-claude-code-shell.plugin.zsh
+++ b/zsh-claude-code-shell.plugin.zsh
@@ -137,16 +137,18 @@ _zsh_claude_accept_line() {
         return 1
     fi
 
+    # Disable job notifications for all background processes in this function.
+    # Using local_options so settings are restored on function exit, but by then
+    # all jobs are already waited-on or disowned — nothing left to notify about.
+    setopt local_options no_notify no_monitor
+
     # Start spinner or show simple message
     local spinner_pid=""
     if [[ "$ZSH_CLAUDE_SHELL_FANCY_LOADING" == "1" ]]; then
         # Print newline so spinner appears below the query line
         print > /dev/tty
-        # Disable job notifications to prevent [1] 12345 and terminated messages
-        setopt local_options no_notify no_monitor
-        _zsh_claude_spinner &
+        _zsh_claude_spinner &!  # &! = background + auto-disown (zsh built-in)
         spinner_pid=$!
-        disown $spinner_pid 2>/dev/null
     else
         zle -R "Generating command with Claude..."
     fi
@@ -183,9 +185,10 @@ _zsh_claude_accept_line() {
         return 130
     ' INT
 
-    # Wait for claude to finish
+    # Wait for claude to finish, then disown to remove from job table
     wait $claude_pid
     exit_code=$?
+    disown $claude_pid 2>/dev/null
 
     # Reset trap and stop spinner
     trap - INT


### PR DESCRIPTION
## Problem

When using the plugin, two extra lines appear after each command generation:
```
[5]  - 3452 terminated  _zsh_claude_spinner
[6]  + 3453 done       claude "${claude_args[@]}" "$query" > "$tmpfile" 2> /dev/null
```

## Root cause

Three issues combined to produce the notifications:

1. `setopt local_options no_notify no_monitor` was inside the `if [[ FANCY_LOADING == 1 ]]` block but the claude process was backgrounded **after** that block — so the scoping worked correctly but the intent was unclear and fragile.
2. The spinner used `& + disown` with a small race window between the two calls.
3. After `wait $claude_pid`, the completed job remained in the job table. When `local_options` restored `MONITOR` on function exit, zsh flushed the pending "done" notification.

## Fix

- Move `setopt local_options no_notify no_monitor` to before all background process launches, covering both the spinner and claude regardless of `FANCY_LOADING`.
- Replace `_zsh_claude_spinner & ; disown` with zsh's built-in `&!` (background + auto-disown atomically).
- Add `disown $claude_pid` after `wait` to remove the completed job from the table while `no_monitor` is still active.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)