### PR TITLE
feat: add zcs direct command for multiline query support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,30 @@ zplug "ArielTM/zsh-claude-code-shell"
 
 ## Usage
 
+### Interactive (`# ` prefix)
+
 1. Type a comment starting with `# ` followed by what you want to do
 2. Press Enter
 3. The comment is replaced with the generated command
 4. Review the command, press Enter to execute (or edit it first)
+
+### Direct (`zcs` command)
+
+Use `zcs` for multiline queries or when you want to generate a command outside of the `# ` flow. The generated command is pre-filled at the next prompt ready to review and run.
+
+```bash
+# single-line
+zcs show top 10 largest files in current directory
+
+# pipe
+echo "kill all node processes" | zcs
+
+# multiline heredoc
+zcs <<EOF
+find all go files
+modified in the last 7 days
+EOF
+```
 
 ### Examples
 
@@ -121,12 +141,14 @@ export ZSH_CLAUDE_SHELL_DISABLED=1
 
 The plugin overrides zsh's `accept-line` widget (the Enter key handler). When you press Enter:
 
-1. If the line starts with `# `, it extracts your description
+1. If the buffer starts with `# `, it extracts your description
 2. Calls `claude -p` with your description
 3. Replaces the buffer with the generated command
 4. You review and press Enter again to execute
 
 Lines that don't start with `# ` work normally.
+
+The `zcs` function works the same way but is called directly. It uses `print -z` to push the generated command into the ZLE input stack, so it appears pre-filled at the next prompt.
 
 ## License
 

--- a/zsh-claude-code-shell.plugin.zsh
+++ b/zsh-claude-code-shell.plugin.zsh
@@ -80,6 +80,33 @@ _zsh_claude_check_cli() {
     return 0
 }
 
+# Direct CLI function - call as: zcs <query> or echo <query> | zcs or zcs <<< "multiline"
+zcs() {
+    local query
+    if [[ $# -gt 0 ]]; then
+        query="$*"
+    else
+        query=$(cat)
+    fi
+
+    [[ -z "${query// }" ]] && { echo "Usage: zcs <query> or echo <query> | zcs" >&2; return 1; }
+    _zsh_claude_check_cli || return 1
+
+    local claude_args=("-p" "--output-format" "text")
+    claude_args+=("--tools" "WebSearch,WebFetch")
+    claude_args+=("--system-prompt" "You are a shell command generator. Your ONLY job is to output a single shell command that accomplishes the user's request. Output ONLY the raw shell command - no markdown, no code blocks, no explanations, no comments, no backticks. Just the executable command itself on a single line. If you need to look up command syntax, you may use web search.")
+    [[ -n "$ZSH_CLAUDE_SHELL_MODEL" ]] && claude_args+=("--model" "$ZSH_CLAUDE_SHELL_MODEL")
+
+    local cmd
+    if [[ "$ZSH_CLAUDE_SHELL_DEBUG" == "1" ]]; then
+        cmd=$(claude "${claude_args[@]}" "$query")
+    else
+        cmd=$(claude "${claude_args[@]}" "$query" 2>/dev/null)
+    fi
+    cmd=$(_zsh_claude_sanitize "$cmd")
+    print -z "$cmd"
+}
+
 # Sanitize output - remove markdown code blocks and trim whitespace
 _zsh_claude_sanitize() {
     local input="$1"


### PR DESCRIPTION
## Summary

- Adds a `zcs` shell function as a direct alternative to the `# ` ZLE widget
- Accepts input as arguments, from a pipe, or via heredoc for multiline queries
- Uses `print -z` to pre-fill the generated command at the next prompt for review before execution
- Updated README with usage examples

## Usage

```bash
# single-line args
zcs show top 10 largest files in current directory

# pipe
echo "kill all node processes" | zcs

# multiline heredoc
zcs <<EOF
find all go files
modified in the last 7 days
EOF
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)