### PR TITLE
fix: update spinner to match Claude Code CLI and fix variable leak

### DIFF
--- a/zsh-claude-code-shell.plugin.zsh
+++ b/zsh-claude-code-shell.plugin.zsh
@@ -231,7 +231,7 @@ _zsh_claude_accept_line() {
     # Build claude command - restrict tools and use focused system prompt
     local claude_args=("-p" "--output-format" "text")
     claude_args+=("--tools" "WebSearch,WebFetch")
-    claude_args+=("--system-prompt" "You are a shell command generator. Your ONLY job is to output a single shell command that accomplishes the user's request. Output ONLY the raw shell command - no markdown, no code blocks, no explanations, no comments, no backticks. Just the executable command itself on a single line. If you need to look up command syntax, you may use web search.")
+    claude_args+=("--system-prompt" "You are a shell command generator running on ${OSTYPE} ($(uname -s) $(uname -m)). Shell: zsh. Your ONLY job is to output a single shell command that accomplishes the user's request. Use commands and flags compatible with this operating system. Output ONLY the raw shell command - no markdown, no code blocks, no explanations, no comments, no backticks. Just the executable command itself on a single line. If you need to look up command syntax, you may use web search.")
 
     if [[ -n "$ZSH_CLAUDE_SHELL_MODEL" ]]; then
         claude_args+=("--model" "$ZSH_CLAUDE_SHELL_MODEL")

--- a/zsh-claude-code-shell.plugin.zsh
+++ b/zsh-claude-code-shell.plugin.zsh
@@ -7,6 +7,9 @@
 : ${ZSH_CLAUDE_SHELL_DEBUG:=0}
 : ${ZSH_CLAUDE_SHELL_FANCY_LOADING:=1}  # Set to 0 to use simple loading message
 
+# Cache platform info at load time (used in system prompt)
+_ZSH_CLAUDE_PLATFORM_INFO="${OSTYPE} ($(uname -s) $(uname -m))"
+
 # Spinner character detection (platform/terminal-aware, matching Claude Code)
 _zsh_claude_spinner_chars() {
     if [[ "$OSTYPE" == darwin* ]]; then
@@ -92,13 +95,14 @@ _zsh_claude_spinner() {
     # Hide cursor
     printf '\033[?25l' > /dev/tty
 
+    local spinner_char output s_start s_end
     while true; do
-        local spinner_char="${frames[$frame_idx]}"
+        spinner_char="${frames[$frame_idx]}"
 
         # Build output with shimmer sweep using substring slicing
-        local output="${base_color}${spinner_char} "
-        local s_start=$(( shimmer_pos - 1 ))
-        local s_end=$(( shimmer_pos + 1 ))
+        output="${base_color}${spinner_char} "
+        s_start=$(( shimmer_pos - 1 ))
+        s_end=$(( shimmer_pos + 1 ))
         (( s_start < 1 )) && s_start=1
         (( s_end > text_len )) && s_end=$text_len
 
@@ -123,7 +127,7 @@ _zsh_claude_spinner() {
         # Advance shimmer every 2 ticks (~240ms, approximating 200ms)
         if (( tick % 2 == 0 )); then
             shimmer_pos=$(( shimmer_pos - 1 ))
-            if (( shimmer_pos < 0 )); then
+            if (( shimmer_pos < 1 )); then
                 shimmer_pos=$text_len
             fi
         fi
@@ -239,7 +243,7 @@ _zsh_claude_accept_line() {
     # Build claude command - restrict tools and use focused system prompt
     local claude_args=("-p" "--output-format" "text")
     claude_args+=("--tools" "WebSearch,WebFetch")
-    claude_args+=("--system-prompt" "You are a shell command generator running on ${OSTYPE} ($(uname -s) $(uname -m)). Shell: zsh. Your ONLY job is to output a single shell command that accomplishes the user's request. Use commands and flags compatible with this operating system. Output ONLY the raw shell command - no markdown, no code blocks, no explanations, no comments, no backticks. Just the executable command itself on a single line. If you need to look up command syntax, you may use web search.")
+    claude_args+=("--system-prompt" "You are a shell command generator running on ${_ZSH_CLAUDE_PLATFORM_INFO}. Shell: zsh. Your ONLY job is to output a single shell command that accomplishes the user's request. Use commands and flags compatible with this operating system. Output ONLY the raw shell command - no markdown, no code blocks, no explanations, no comments, no backticks. Just the executable command itself on a single line. If you need to look up command syntax, you may use web search.")
 
     if [[ -n "$ZSH_CLAUDE_SHELL_MODEL" ]]; then
         claude_args+=("--model" "$ZSH_CLAUDE_SHELL_MODEL")

--- a/zsh-claude-code-shell.plugin.zsh
+++ b/zsh-claude-code-shell.plugin.zsh
@@ -7,54 +7,129 @@
 : ${ZSH_CLAUDE_SHELL_DEBUG:=0}
 : ${ZSH_CLAUDE_SHELL_FANCY_LOADING:=1}  # Set to 0 to use simple loading message
 
+# Spinner character detection (platform/terminal-aware, matching Claude Code)
+_zsh_claude_spinner_chars() {
+    if [[ "$OSTYPE" == darwin* ]]; then
+        if [[ -n "$GHOSTTY_RESOURCES_DIR" ]]; then
+            echo '· ✢ ✳ ✶ ✻ *'
+        else
+            echo '· ✢ ✳ ✶ ✻ ✽'
+        fi
+    else
+        echo '· ✢ * ✶ ✻ ✽'
+    fi
+}
+
 # Thinking verbs (from Claude Code)
 _ZSH_CLAUDE_THINKING_VERBS=(
-    "Accomplishing" "Actioning" "Actualizing" "Baking" "Brewing"
-    "Calculating" "Cerebrating" "Churning" "Clauding" "Coalescing"
-    "Cogitating" "Computing" "Conjuring" "Considering" "Cooking"
-    "Crafting" "Creating" "Crunching" "Deliberating" "Determining"
-    "Doing" "Effecting" "Finagling" "Forging" "Forming" "Generating"
-    "Hatching" "Herding" "Honking" "Hustling" "Ideating" "Inferring"
-    "Manifesting" "Marinating" "Moseying" "Mulling" "Mustering" "Musing"
-    "Noodling" "Percolating" "Pondering" "Processing" "Puttering"
-    "Reticulating" "Ruminating" "Schlepping" "Shucking" "Simmering"
-    "Smooshing" "Spinning" "Stewing" "Synthesizing" "Thinking"
-    "Transmuting" "Vibing" "Working"
+    "Accomplishing" "Actioning" "Actualizing" "Architecting" "Baking"
+    "Beaming" "Beboppin'" "Befuddling" "Billowing" "Blanching"
+    "Bloviating" "Boogieing" "Boondoggling" "Booping" "Bootstrapping"
+    "Brewing" "Bunning" "Burrowing" "Calculating" "Canoodling"
+    "Caramelizing" "Cascading" "Catapulting" "Cerebrating" "Channeling"
+    "Channelling" "Choreographing" "Churning" "Clauding" "Coalescing"
+    "Cogitating" "Combobulating" "Composing" "Computing" "Concocting"
+    "Considering" "Contemplating" "Cooking" "Crafting" "Creating"
+    "Crunching" "Crystallizing" "Cultivating" "Deciphering" "Deliberating"
+    "Determining" "Dilly-dallying" "Discombobulating" "Doing" "Doodling"
+    "Drizzling" "Ebbing" "Effecting" "Elucidating" "Embellishing"
+    "Enchanting" "Envisioning" "Evaporating" "Fermenting" "Fiddle-faddling"
+    "Finagling" "Flambéing" "Flibbertigibbeting" "Flowing" "Flummoxing"
+    "Fluttering" "Forging" "Forming" "Frolicking" "Frosting"
+    "Gallivanting" "Galloping" "Garnishing" "Generating" "Gesticulating"
+    "Germinating" "Gitifying" "Grooving" "Gusting" "Harmonizing"
+    "Hashing" "Hatching" "Herding" "Honking" "Hullaballooing"
+    "Hyperspacing" "Ideating" "Imagining" "Improvising" "Incubating"
+    "Inferring" "Infusing" "Ionizing" "Jitterbugging" "Julienning"
+    "Kneading" "Leavening" "Levitating" "Lollygagging" "Manifesting"
+    "Marinating" "Meandering" "Metamorphosing" "Misting" "Moonwalking"
+    "Moseying" "Mulling" "Mustering" "Musing" "Nebulizing"
+    "Nesting" "Newspapering" "Noodling" "Nucleating" "Orbiting"
+    "Orchestrating" "Osmosing" "Perambulating" "Percolating" "Perusing"
+    "Philosophising" "Photosynthesizing" "Pollinating" "Pondering" "Pontificating"
+    "Pouncing" "Precipitating" "Prestidigitating" "Processing" "Proofing"
+    "Propagating" "Puttering" "Puzzling" "Quantumizing" "Razzle-dazzling"
+    "Razzmatazzing" "Recombobulating" "Reticulating" "Roosting" "Ruminating"
+    "Sautéing" "Scampering" "Schlepping" "Scurrying" "Seasoning"
+    "Shenaniganing" "Shimmying" "Simmering" "Skedaddling" "Sketching"
+    "Slithering" "Smooshing" "Sock-hopping" "Spelunking" "Spinning"
+    "Sprouting" "Stewing" "Sublimating" "Swirling" "Swooping"
+    "Symbioting" "Synthesizing" "Tempering" "Thinking" "Thundering"
+    "Tinkering" "Tomfoolering" "Topsy-turvying" "Transfiguring" "Transmuting"
+    "Twisting" "Undulating" "Unfurling" "Unravelling" "Vibing"
+    "Waddling" "Wandering" "Warping" "Whatchamacalliting" "Whirlpooling"
+    "Whirring" "Whisking" "Wibbling" "Working" "Wrangling"
+    "Zesting" "Zigzagging"
 )
 
 # Spinner animation (runs in background, writes to /dev/tty)
 _zsh_claude_spinner() {
-    local spinchars='✽⊹✦◈'
-    local spin_len=4
-    local words_len=${#_ZSH_CLAUDE_THINKING_VERBS[@]}
-    local i=1
-    local w=$(( RANDOM % words_len + 1 ))  # Start with random word
-    local tick=0
+    # Build ping-pong frame sequence from platform-appropriate characters
+    local -a base_chars=(${(s: :)$(_zsh_claude_spinner_chars)})
+    local -a frames=("${base_chars[@]}")
+    local k
+    for ((k=${#base_chars[@]}; k>=1; k--)); do
+        frames+=("${base_chars[$k]}")
+    done
+    local frame_count=${#frames[@]}
 
-    # Colors for shimmering effect (cyan gradient)
-    local -a colors=('\033[96m' '\033[36m' '\033[96m' '\033[36m')
-    local color_idx=1
+    # Colors (Claude Code theme: salmon/orange)
+    local base_color='\033[38;5;174m'
+    local shimmer_color='\033[38;5;216m'
+    local reset_color='\033[0m'
+
+    # State
+    local words_len=${#_ZSH_CLAUDE_THINKING_VERBS[@]}
+    local frame_idx=1
+    local w=$(( RANDOM % words_len + 1 ))
+    local tick=0
+    local word="${_ZSH_CLAUDE_THINKING_VERBS[$w]}"
+    local full_text="${word}…"
+    local text_len=${#full_text}
+    local shimmer_pos=$text_len
 
     # Hide cursor
     printf '\033[?25l' > /dev/tty
 
     while true; do
-        local char="${spinchars[$i]}"
-        local word="${_ZSH_CLAUDE_THINKING_VERBS[$w]}"
-        local color="${colors[$color_idx]}"
+        local spinner_char="${frames[$frame_idx]}"
 
-        # Print spinner with shimmering color effect
-        printf '\r\033[K%b%s %s...\033[0m' "$color" "$char" "$word" > /dev/tty
+        # Build output with per-character shimmer sweep
+        local output="${base_color}${spinner_char} "
+        local j
+        for ((j=1; j<=text_len; j++)); do
+            if (( j >= shimmer_pos - 1 && j <= shimmer_pos + 1 )); then
+                output+="${shimmer_color}${full_text[$j]}"
+            else
+                output+="${base_color}${full_text[$j]}"
+            fi
+        done
+        output+="${reset_color}"
 
-        i=$(( i % spin_len + 1 ))
+        printf '\r\033[K%b' "$output" > /dev/tty
+
+        # Advance frame (ping-pong)
+        frame_idx=$(( frame_idx % frame_count + 1 ))
         tick=$(( tick + 1 ))
-        color_idx=$(( color_idx % 4 + 1 ))
 
-        # Change word every ~12 ticks (~1.2 seconds)
-        if (( tick % 12 == 0 )); then
-            w=$(( RANDOM % words_len + 1 ))
+        # Advance shimmer every 2 ticks (~240ms, approximating 200ms)
+        if (( tick % 2 == 0 )); then
+            shimmer_pos=$(( shimmer_pos - 1 ))
+            if (( shimmer_pos < 0 )); then
+                shimmer_pos=$text_len
+            fi
         fi
-        sleep 0.1
+
+        # Change verb every 20 ticks (~2.4 seconds)
+        if (( tick % 20 == 0 )); then
+            w=$(( RANDOM % words_len + 1 ))
+            word="${_ZSH_CLAUDE_THINKING_VERBS[$w]}"
+            full_text="${word}…"
+            text_len=${#full_text}
+            shimmer_pos=$text_len
+        fi
+
+        sleep 0.12
     done
 }
 

--- a/zsh-claude-code-shell.plugin.zsh
+++ b/zsh-claude-code-shell.plugin.zsh
@@ -67,9 +67,10 @@ _zsh_claude_spinner() {
     # Build ping-pong frame sequence from platform-appropriate characters
     local -a base_chars=(${(s: :)$(_zsh_claude_spinner_chars)})
     local -a frames=("${base_chars[@]}")
-    local k
-    for ((k=${#base_chars[@]}; k>=1; k--)); do
+    local k=${#base_chars[@]}
+    while (( k >= 1 )); do
         frames+=("${base_chars[$k]}")
+        k=$(( k - 1 ))
     done
     local frame_count=${#frames[@]}
 
@@ -94,16 +95,23 @@ _zsh_claude_spinner() {
     while true; do
         local spinner_char="${frames[$frame_idx]}"
 
-        # Build output with per-character shimmer sweep
+        # Build output with shimmer sweep using substring slicing
         local output="${base_color}${spinner_char} "
-        local j
-        for ((j=1; j<=text_len; j++)); do
-            if (( j >= shimmer_pos - 1 && j <= shimmer_pos + 1 )); then
-                output+="${shimmer_color}${full_text[$j]}"
-            else
-                output+="${base_color}${full_text[$j]}"
-            fi
-        done
+        local s_start=$(( shimmer_pos - 1 ))
+        local s_end=$(( shimmer_pos + 1 ))
+        (( s_start < 1 )) && s_start=1
+        (( s_end > text_len )) && s_end=$text_len
+
+        # Before shimmer
+        if (( s_start > 1 )); then
+            output+="${base_color}${full_text[1,$((s_start - 1))]}"
+        fi
+        # Shimmer zone
+        output+="${shimmer_color}${full_text[$s_start,$s_end]}"
+        # After shimmer
+        if (( s_end < text_len )); then
+            output+="${base_color}${full_text[$((s_end + 1)),$text_len]}"
+        fi
         output+="${reset_color}"
 
         printf '\r\033[K%b' "$output" > /dev/tty


### PR DESCRIPTION
## Summary
- Updated spinner animation to match the Claude Code CLI: ping-pong character cycle, salmon/orange shimmer sweep, platform-aware spinner characters, and expanded thinking verbs list (~160 entries)
- Fixed zsh C-style `for ((j=1; j<=n; j++))` loop leaking the final value of `j` to stdout (e.g. `✶ Frosting…j=10`) by switching to `while` loops and substring slicing
- Fixed shimmer reset off-by-one: position now resets at `< 1` instead of `< 0` to avoid a degenerate frame on 1-indexed strings
- Moved loop-local variable declarations (`spinner_char`, `output`, `s_start`, `s_end`) outside the hot loop to avoid redundant re-declarations
- Included OS info in the system prompt for platform-appropriate command generation, cached at plugin load time to avoid repeated `uname` calls

## Test plan
- [ ] Verify spinner displays cleanly without any leaked variable values
- [ ] Confirm shimmer animation sweeps smoothly across the text with no visual glitch at the reset boundary
- [ ] Test verb rotation still works every ~2.4 seconds
- [ ] Verify spinner characters adapt to platform (macOS vs Linux) and terminal (Ghostty)
- [ ] Confirm generated commands are OS-appropriate (e.g. `pbcopy` on macOS, `xclip` on Linux)